### PR TITLE
Minor fix for warning message

### DIFF
--- a/stdc++.h
+++ b/stdc++.h
@@ -26,10 +26,6 @@
  *  This is an implementation file for a precompiled header.
   */
 
-// Also writing "using namespace std;" here so that you dont need to write it everytime you start a cpp file
-
-using namespace std;
-
 
   // 17.4.1.2 Headers
 
@@ -119,3 +115,7 @@ using namespace std;
   #include <unordered_map>
   #include <unordered_set>
   #endif
+
+// Also writing "using namespace std;" here so that you dont need to write it everytime you start a cpp file
+
+using namespace std;


### PR DESCRIPTION
**What changed**
Moved `using namespace std` to the end of the file

**Why?**
I was getting this warning message after compiling (`g++ -std=c++11 -o ttt tictactoe.cpp`) my code.
```
/usr/local/include/bits/stdc++.h:31:17: warning: using directive refers to implicitly-defined namespace 'std'
using namespace std;
                ^
1 warning generated.
```

**What solved it?**
I came across this [stack overflow answer](https://stackoverflow.com/a/28395342/3728336) which suggested to put the `using namespace std` after the `#include`. I made the said changes and it worked for me i.e, I'm not getting that warning message anymore. 