### PR TITLE
This method worked for me, I am on the latest BigSur version 11.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ or
 * Create stdc++.h file (touch stdc++.h or vim stdc++.h)
 * Paste the contents of the stdc+.h file here
 
+or 
+* Inside the directory /Library/Developer/CommandLineTools/usr/include/c++/v1
+* Create a directory named bits (mkdir bits)
+* Create stdc++.h file (touch stdc++.h or vim stdc++.h)
+* Paste the contents of the stdc+.h file here
+
 Now it should compile as expected
 
 I have also included "using namespace std;" in this file.


### PR DESCRIPTION
I am currently using [LunarVim](https://github.com/LunarVim/LunarVim), 
LunarVim utilises the benefit of clang for formatting and showing errors/warnings.
Though `#include <bits/stdc++.h>`  working fine on compiling and running, but clang always throw errors and warnings on saving.
After including` bits/stdc++` in mentioned directory, I am not seeing any error/warning.


**Before** 

![before](https://user-images.githubusercontent.com/33067129/128706201-5fd852ed-871f-4cf8-b968-3ea26f021ef7.png)

**After**

![after](https://user-images.githubusercontent.com/33067129/128706191-ab0c730d-e2c2-443e-bdcb-4bc3dd951113.png)

