### PR TITLE
Updated exception handling headers

### DIFF
--- a/stdc++.h
+++ b/stdc++.h
@@ -62,6 +62,8 @@ using namespace std;
   #include <ctgmath>
   #include <cwchar>
   #include <cwctype>
+  #include <exception>
+  #include <stdexcept>
   #endif
 
   // C++


### PR DESCRIPTION
These headers are needed to handle exceptions in C++. <stdexcept.h> can be added instead of exception for earlier versions